### PR TITLE
Fixed the error: type object 'datetime.datetime' has no attribute 'da…

### DIFF
--- a/probemon.py
+++ b/probemon.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 import time
-import datetime
+from datetime import datetime
 import argparse
 import netaddr
 import sys
@@ -33,7 +33,7 @@ def build_packet_callback(time_fmt, logger, delimiter, mac_info, ssid, rssi):
 		# determine preferred time format 
 		log_time = str(int(time.time()))
 		if time_fmt == 'iso':
-			log_time = datetime.datetime.now().isoformat()
+			log_time = datetime.now().isoformat()
 
 		fields.append(log_time)
 


### PR DESCRIPTION
Running probemon.py on Raspberry pi3 with Kali Linux as OS getting error:  

    root@kali:~# python probemon.py -i wlan1  
    Traceback (most recent call last):
      File "probemon.py", line 99, in <module>
        main()
      File "probemon.py", line 96, in main
        sniff(iface=args.interface, prn=built_packet_cb, store=0)
      File "/usr/lib/python2.7/dist-packages/scapy/sendrecv.py", line 620, in sniff
        r = prn(p)
      File "probemon.py", line 37, in packet_callback
        log_time = datetime.datetime.now().isoformat()
     AttributeError: type object 'datetime.datetime' has no attribute 'datetime'` 

Error has been resolved by the suggested changes.