### PR TITLE
Manage to work with utf-8 ssid

### DIFF
--- a/probemon.py
+++ b/probemon.py
@@ -56,7 +56,7 @@ def build_packet_callback(time_fmt, logger, delimiter, mac_info, ssid, rssi):
 			rssi_val = -(256-ord(packet.notdecoded[-4:-3]))
 			fields.append(str(rssi_val))
 
-		logger.info(delimiter.join(fields))
+		logger.info(delimiter.join([f.decode("utf-8") for f in fields]))
 
 	return packet_callback
 


### PR DESCRIPTION
This changes corrects this exception:
_Traceback (most recent call last):
  File "probemon.py", line 94, in <module>
    main()
  File "probemon.py", line 91, in main
    sniff(iface=args.interface, prn=built_packet_cb, store=0)
  File "/home/llacheny/.local/lib/python2.7/site-packages/scapy/sendrecv.py", line 620, in sniff
    r = prn(p)
  File "probemon.py", line 57, in packet_callback
    logger.info(delimiter.join(fields))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xb6 in position 28: ordinal not in range(128)_
